### PR TITLE
Fix console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,2 @@
 all:
-	sass --update sass:stylesheets
-	coffee -o js/ -c coffeescripts/
+	jekyll serve

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+gems:
+  - jekyll-coffeescript

--- a/js/console.coffee
+++ b/js/console.coffee
@@ -19,6 +19,7 @@ load = (query = "") ->
   $.ajax
     type: "GET"
     url: url
+    dataType: "text"
     success: (data) =>
       $("#load").removeClass("disabled").val("Load")
       $("#output").removeClass("loading")

--- a/js/console.coffee
+++ b/js/console.coffee
@@ -29,7 +29,7 @@ load = (query = "") ->
 $ ->
   $("#domain").html BASE
   load location.hash.substring(1)
-        
+
   $("#query-form").on "submit", (e) ->
     e.preventDefault()
     location.hash = $("#query").val()


### PR DESCRIPTION
The PCR Console was designed with plain text responses from the PCR API in mind.
However, when we upgraded the PCR API to set the content type correctly to JSON,
jQuery automatically started transforming the data into a JSON object, wreaking
havoc on the regex and HTML insertion in the console. By explicitly setting the
dataType of the ajax query to "text", we can get the original behavior again.

Fixes #1